### PR TITLE
Split up the adapter class WeekAndSerializableConverter.java

### DIFF
--- a/src/main/java/com/csc207/api/WeekController.java
+++ b/src/main/java/com/csc207/api/WeekController.java
@@ -2,7 +2,7 @@ package com.csc207.api;
 
 import com.csc207.domain.TaskSerializable;
 import com.csc207.domain.Week;
-import com.csc207.domain.WeekAndSerializableConverter;
+import com.csc207.domain.WeekToSerializableAdapter;
 import com.csc207.domain.WeekSerializable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,9 +26,9 @@ public class WeekController {
     @Transactional
     public void saveWeek(Week week) {
         // convert to week serializable
-        WeekSerializable convertedWeek = WeekAndSerializableConverter.WeekToWeekSerializable(week);
+        WeekSerializable convertedWeek = WeekToSerializableAdapter.WeekToWeekSerializable(week);
         // convert to task serializable
-        ArrayList<TaskSerializable> convertedTasks = WeekAndSerializableConverter.WeekToTaskSerializable(week);
+        ArrayList<TaskSerializable> convertedTasks = WeekToSerializableAdapter.WeekToTaskSerializable(week);
         // save weekSerializable
         this.weekSerializableInteractor.saveWeekSerializable(convertedWeek);
         // save taskSerializable

--- a/src/main/java/com/csc207/cli/UserInterface.java
+++ b/src/main/java/com/csc207/cli/UserInterface.java
@@ -160,7 +160,7 @@ public class UserInterface {
             this.weekSerializableInteractor.removeWeekSerializableByUserId(userId);
             ArrayList<TaskSerializable> tasksSers = this.taskSerializableInteractor.getTasksByUserId(userId);
             this.taskSerializableInteractor.removeTaskSerializablesByUserId(userId);
-            week = WeekAndSerializableConverter.SerializableToWeek(weekSers, tasksSers);
+            week = SerializableToWeekAdapter.SerializableToWeek(weekSers, tasksSers);
         } else {
             System.out.println("Please enter a valid option.");
             int newSelection = Integer.parseInt(reader.nextLine());

--- a/src/main/java/com/csc207/domain/SerializableToWeekAdapter.java
+++ b/src/main/java/com/csc207/domain/SerializableToWeekAdapter.java
@@ -1,37 +1,8 @@
 package com.csc207.domain;
 
-import com.csc207.domain.*;
-
 import java.util.ArrayList;
 
-public class WeekAndSerializableConverter {
-
-    /**
-     * Convert a Week to a WeekSerializable to be saved to a database.
-     *
-     * @param week: the Week to be converted to a WeekSerializable
-     * @return the WeekSerializable corresponding to this Week.
-     */
-    public static WeekSerializable WeekToWeekSerializable(Week week){
-        return new WeekSerializable(week.getDays()[0].getDayOfMonth(), week.getUserId());
-    }
-
-    /**
-     * Convert a Week to an array of TaskSerializables
-     *
-     * @param week: the Week to be converted to a TaskSerializable.
-     * @return an Array of TaskSerializables corresponding to this Week.
-     */
-    public static ArrayList<TaskSerializable> WeekToTaskSerializable(Week week){
-        ArrayList<TaskSerializable> taskSers = new ArrayList<>();
-        for(Day day: week.getDays()){
-            for(Task task: day.getTodayTasks()){
-                taskSers.add(new TaskSerializable(task.getName(), task.getStartDateTime(), task.getDuration(), task.isCompleted(), task.getUserId()));
-            }
-        }
-        return taskSers;
-    }
-
+public class SerializableToWeekAdapter {
     /**
      * Convert a WeekSerializable and an Array of TaskSerializables into a Week.
      *

--- a/src/main/java/com/csc207/domain/WeekToSerializableAdapter.java
+++ b/src/main/java/com/csc207/domain/WeekToSerializableAdapter.java
@@ -1,0 +1,33 @@
+package com.csc207.domain;
+
+import java.util.ArrayList;
+
+public class WeekToSerializableAdapter {
+
+    /**
+     * Convert a Week to a WeekSerializable to be saved to a database.
+     *
+     * @param week: the Week to be converted to a WeekSerializable
+     * @return the WeekSerializable corresponding to this Week.
+     */
+    public static WeekSerializable WeekToWeekSerializable(Week week){
+        return new WeekSerializable(week.getDays()[0].getDayOfMonth(), week.getUserId());
+    }
+
+    /**
+     * Convert a Week to an array of TaskSerializables
+     *
+     * @param week: the Week to be converted to a TaskSerializable.
+     * @return an Array of TaskSerializables corresponding to this Week.
+     */
+    public static ArrayList<TaskSerializable> WeekToTaskSerializable(Week week){
+        ArrayList<TaskSerializable> taskSers = new ArrayList<>();
+        for(Day day: week.getDays()){
+            for(Task task: day.getTodayTasks()){
+                taskSers.add(new TaskSerializable(task.getName(), task.getStartDateTime(), task.getDuration(), task.isCompleted(), task.getUserId()));
+            }
+        }
+        return taskSers;
+    }
+
+}

--- a/src/test/java/com/csc207/api/WeekAndSerializableConverterTest.java
+++ b/src/test/java/com/csc207/api/WeekAndSerializableConverterTest.java
@@ -41,7 +41,7 @@ public class WeekAndSerializableConverterTest {
     @Test
     public void testWeekToWeekSerializable(){
         WeekSerializable expected = new WeekSerializable(startDate, 1L);
-        assertEquals(expected, WeekAndSerializableConverter.WeekToWeekSerializable(week));
+        assertEquals(expected, WeekToSerializableAdapter.WeekToWeekSerializable(week));
     }
 
     /**
@@ -50,7 +50,7 @@ public class WeekAndSerializableConverterTest {
     @Test
     public void testWeekToTaskSerializable(){
         ArrayList<TaskSerializable> expected = new ArrayList<>();
-        assertEquals(expected, WeekAndSerializableConverter.WeekToTaskSerializable(week));
+        assertEquals(expected, WeekToSerializableAdapter.WeekToTaskSerializable(week));
     }
 
     /**
@@ -60,6 +60,6 @@ public class WeekAndSerializableConverterTest {
     public void testSerializableToWeek(){
         WeekSerializable weekSers = new WeekSerializable(startDate, 1L);
         ArrayList<TaskSerializable> taskSers = new ArrayList<>();
-        assertEquals(week, WeekAndSerializableConverter.SerializableToWeek(weekSers, taskSers));
+        assertEquals(week, SerializableToWeekAdapter.SerializableToWeek(weekSers, taskSers));
     }
 }


### PR DESCRIPTION
Split up the adapter class WeekAndSerializableConverter.java into WeekToSerializableAdapter.java and SerializableToWeekAdapter.java, to keep in line with the adapter design pattern and SRP.